### PR TITLE
Move anchor=north before this umlcd style in class etc.

### DIFF
--- a/pgf-umlcd.sty
+++ b/pgf-umlcd.sty
@@ -64,7 +64,7 @@ minimum height=1cm, node distance=2cm]
 \begin{classAndInterfaceCommon}{#1}{#2}{#3}
 }%
 {\calcuateNumberOfParts{}
-\node[this umlcd style, anchor=north] (\umlcdClassName) at (\umlcdClassPos)
+\node[anchor=north, this umlcd style] (\umlcdClassName) at (\umlcdClassPos)
     {\textbf{\umlcdClassName}
 \insertAttributesAndOperations{}
 };
@@ -77,7 +77,7 @@ minimum height=1cm, node distance=2cm]
 \begin{classAndInterfaceCommon}{#1}{#2}{#3}
 }%
 {\calcuateNumberOfParts{}
-\node[this umlcd style, anchor=north] (\umlcdClassName) at (\umlcdClassPos)
+\node[anchor=north,this umlcd style] (\umlcdClassName) at (\umlcdClassPos)
     {$<<$interface$>>$ \\ \textbf{\umlcdClassName}
 \insertAttributesAndOperations{}
 };
@@ -90,7 +90,7 @@ minimum height=1cm, node distance=2cm]
 \begin{classAndInterfaceCommon}{#1}{#2}{#3}
 }%
 {\calcuateNumberOfParts{}
-\node[this umlcd style, anchor=north] (\umlcdClassName) at (\umlcdClassPos)
+\node[anchor=north, this umlcd style] (\umlcdClassName) at (\umlcdClassPos)
     {$<<$abstract$>>$ \\ \textbf{\umlcdClassName}
 \insertAttributesAndOperations{}
 };
@@ -127,7 +127,7 @@ minimum height=1cm, node distance=2cm]
 		\def\umldObjectName{\umlcdClassName : \@instanceOf}
 	\fi
 
-\node[this umlcd style, anchor=north, umlcd style school] (\umlcdClassName) at (\umlcdClassPos)
+\node[anchor=north, this umlcd style, umlcd style school] (\umlcdClassName) at (\umlcdClassPos)
     { \ifschool
 				\textbf{\umldObjectName}
 			\else 


### PR DESCRIPTION
Based on https://tex.stackexchange.com/questions/396431/is-there-any-method-to-create-uml-using-latex-without-giving-x-y-co-ordinate

By moving `anchor=north` before `this umlcd style` in the `class`, `interface`, `abstractclass`, and `object` classes, you increase the flexibility of the package, as you can set the anchor of the node in the optional argument to the environment, e.g. 

    \begin{class}[anchor=east]{foo}{x,y}

This makes positioning of diagram elements easier, as described in the TeX.SX post linked to above.